### PR TITLE
[모수진][#30] 로그인 페이지 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7868,7 +7868,6 @@
       "version": "7.53.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.2.tgz",
       "integrity": "sha512-YVel6fW5sOeedd1524pltpHX+jgU2u3DSDtXEaBORNdqiNrsX/nUI/iGXONegttg0mJVnfrIkiV0cmTU6Oo2xw==",
-      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -8,21 +8,34 @@ interface FormTypes {
   pwd: string;
 }
 export default function Login() {
-  const { register, handleSubmit } = useForm<FormTypes>();
+  const { register, handleSubmit, formState: { errors }, } = useForm<FormTypes>({ mode: "onBlur"});
   const onValid = (data: FormTypes) => console.log(data);
+
   return (
     <div className={style.containerLogin}>
       <div className={style.containerHeader}>로그인</div>
         <form className={style.containerForm} onSubmit={handleSubmit(onValid)}>
           <label className={style.containerLabel} htmlFor="email">
             이메일<br />
-            <input className={style.containerInput} {...register("email", {required: true, minLength: 8})}
-             name="email" type="text" placeholder="이메일을 입력해 주세요" />
+            <input className={`${style.containerInput} ${errors.email ? style.errorInput : ""}`} 
+            {...register("email", { required: "이메일 형식으로 작성해 주세요.", 
+              pattern: {
+                value: /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,4}$/i,
+                message: "이메일 형식으로 작성해 주세요.",
+              },})}
+             id="email" name="email" type="text" placeholder="이메일을 입력해 주세요" />
+             { errors.email && <small className={style.tagAlert} role="alert">{errors.email.message}</small>}
           </label><br />
           <label className={style.containerLabel} htmlFor="pwd">
             비밀번호<br />
-            <input className={style.containerInput} {...register("pwd", {required: true, minLength: 8})}
-            name="pwd" type="password" placeholder="비밀번호를 입력해 주세요" />
+            <input className={`${style.containerInput} ${errors.pwd ? style.errorInput : ""}`} 
+            {...register("pwd", {required: "8자 이상 입력해 주세요.", 
+            minLength: {
+              value: 8,
+              message: "8자 이상 입력해 주세요.",
+            },})}
+            id="pwd" name="pwd" type="password" placeholder="비밀번호를 입력해 주세요" />
+            { errors.pwd && <small className={style.tagAlert} role="alert">{errors.pwd.message}</small> }
           </label><br />
           <input className={style.btnLogin} type="submit" value="로그인" />
         </form><br /><br />

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,6 +2,9 @@
 
 import style from "@/styles/login/style.module.scss";
 import { useForm } from "react-hook-form";
+import { useRef, useState } from "react";
+import { postSignIn } from '@/api/swagger/Auth';
+import { SignInProps, SignInData } from '@/api/swagger/Wikid.types';
 
 interface FormTypes {
   email: string;
@@ -9,7 +12,28 @@ interface FormTypes {
 }
 export default function Login() {
   const { register, handleSubmit, formState: { errors }, } = useForm<FormTypes>({ mode: "onBlur"});
-  const onValid = (data: FormTypes) => console.log(data);
+
+  const [success, setSuccess] = useState(false);
+
+  const [signIn, setSignIn] = useState<SignInData | null>(null);
+
+  const onValid = async (data: FormTypes) => {
+    const reqData = {
+      email: data.email,
+      password: data.pwd,
+    };
+
+    try {
+      const resData = await postSignIn(reqData);
+      setSignIn(resData)
+      console.log(JSON.stringify(resData));
+      setSuccess(true);
+    } catch (e) {
+      console.log(e);
+      alert('이메일 또는 비밀번호가 일치하지 않습니다.');
+      setSuccess(false);
+    } 
+  }
 
   return (
     <div className={style.containerLogin}>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,19 +1,30 @@
-import style from "@/styles/login/style.module.scss";
+"use client"
 
+import style from "@/styles/login/style.module.scss";
+import { useForm } from "react-hook-form";
+
+interface FormTypes {
+  email: string;
+  pwd: string;
+}
 export default function Login() {
+  const { register, handleSubmit } = useForm<FormTypes>();
+  const onValid = (data: FormTypes) => console.log(data);
   return (
     <div className={style.containerLogin}>
       <div className={style.containerHeader}>로그인</div>
-        <form className={style.containerForm}>
+        <form className={style.containerForm} onSubmit={handleSubmit(onValid)}>
           <label className={style.containerLabel} htmlFor="email">
             이메일<br />
-            <input className={style.containerInput} name="email" type="text" placeholder="이메일을 입력해 주세요" />
+            <input className={style.containerInput} {...register("email", {required: true, minLength: 8})}
+             name="email" type="text" placeholder="이메일을 입력해 주세요" />
           </label><br />
           <label className={style.containerLabel} htmlFor="pwd">
             비밀번호<br />
-            <input className={style.containerInput} name="pwd" type="password" placeholder="비밀번호를 입력해 주세요" />
+            <input className={style.containerInput} {...register("pwd", {required: true, minLength: 8})}
+            name="pwd" type="password" placeholder="비밀번호를 입력해 주세요" />
           </label><br />
-          <input className={style.btnLogin} type="button" value="로그인" />
+          <input className={style.btnLogin} type="submit" value="로그인" />
         </form><br /><br />
         <div className={style.containerSignup}><a href="/signup">회원가입</a></div>
     </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,25 +2,21 @@
 
 import style from "@/styles/login/style.module.scss";
 import { useForm } from "react-hook-form";
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { postSignIn } from '@/api/swagger/Auth';
 import { SignInProps, SignInData } from '@/api/swagger/Wikid.types';
 
-interface FormTypes {
-  email: string;
-  pwd: string;
-}
 export default function Login() {
-  const { register, handleSubmit, formState: { errors }, } = useForm<FormTypes>({ mode: "onBlur"});
+  const { register, handleSubmit, formState: { errors }, } = useForm<SignInProps>({ mode: "onBlur"});
 
   const [success, setSuccess] = useState(false);
 
   const [signIn, setSignIn] = useState<SignInData | null>(null);
 
-  const onValid = async (data: FormTypes) => {
+  const onValid = async (data: SignInProps) => {
     const reqData = {
       email: data.email,
-      password: data.pwd,
+      password: data.password,
     };
 
     try {
@@ -50,16 +46,16 @@ export default function Login() {
              id="email" name="email" type="text" placeholder="이메일을 입력해 주세요" />
              { errors.email && <small className={style.tagAlert} role="alert">{errors.email.message}</small>}
           </label><br />
-          <label className={style.containerLabel} htmlFor="pwd">
+          <label className={style.containerLabel} htmlFor="password">
             비밀번호<br />
-            <input className={`${style.containerInput} ${errors.pwd ? style.errorInput : ""}`} 
-            {...register("pwd", {required: "8자 이상 입력해 주세요.", 
+            <input className={`${style.containerInput} ${errors.password ? style.errorInput : ""}`} 
+            {...register("password", {required: "8자 이상 입력해 주세요.", 
             minLength: {
               value: 8,
               message: "8자 이상 입력해 주세요.",
             },})}
-            id="pwd" name="pwd" type="password" placeholder="비밀번호를 입력해 주세요" />
-            { errors.pwd && <small className={style.tagAlert} role="alert">{errors.pwd.message}</small> }
+            id="password" name="password" type="password" placeholder="비밀번호를 입력해 주세요" />
+            { errors.password && <small className={style.tagAlert} role="alert">{errors.password.message}</small> }
           </label><br />
           <input className={style.btnLogin} type="submit" value="로그인" />
         </form><br /><br />

--- a/src/styles/login/style.module.scss
+++ b/src/styles/login/style.module.scss
@@ -57,6 +57,7 @@
 .containerInput:focus {
   border: 2px solid $green-200;
 }
+
 .errorInput {
   border-color: $red;
   background-color: $red-100;

--- a/src/styles/login/style.module.scss
+++ b/src/styles/login/style.module.scss
@@ -64,6 +64,7 @@
   font-weight: 600;
   color: $gray-100;
   text-align: center;
+  cursor: pointer;
 }
 
 .containerSignup {

--- a/src/styles/login/style.module.scss
+++ b/src/styles/login/style.module.scss
@@ -45,6 +45,7 @@
   background-color: $gray-100;
   border-radius: 10px;
   padding: 14px 20px;
+  outline: none;
 }
 
 .containerInput::placeholder {
@@ -53,6 +54,16 @@
   color: $gray-400;
 }
 
+.containerInput:focus {
+  border: 2px solid $green-200;
+}
+.errorInput {
+  border-color: $red;
+  background-color: $red-100;
+}
+.tagAlert {
+  color: $red;
+}
 .btnLogin {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## 주요 변경점
- 유효성 검사(결과1)
- api 연결(결과2,3)


## 실행 결과
![스크린샷 2024-11-27 140920](https://github.com/user-attachments/assets/b4b9f32f-063a-45bc-bcc1-5992dd5dde85)
![스크린샷 2024-11-27 141412](https://github.com/user-attachments/assets/dd415519-0e68-4d0a-a89a-be168fafcad7)
![스크린샷 2024-11-27 140955](https://github.com/user-attachments/assets/7de34397-5aef-4a52-9d89-ddf66bcb7154)


## 관련 이슈
#30 


## 이후 개선
- 로그인 성공 시 랜딩 페이지로 이동
- 로그인 성공 시 액세스 토큰 할당